### PR TITLE
feat!: migrate to Essentials v3 / net8

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,28 @@
+# Commit Conventions (required)
+
+This repository uses **semantic-release** with **Conventional Commits**. CI derives the next
+version *entirely* from commit-message prefixes. A commit without a release-triggering prefix
+produces **no new version**, and the `build-*` CI jobs are **skipped** (the run looks green but
+no artifact is produced). Every commit — by a human or an AI agent — MUST use a Conventional
+Commit message:
+
+| Prefix | Effect | Use for |
+|--------|--------|---------|
+| `feat:` | minor bump | a new user-facing feature |
+| `fix:` | patch bump | a bug fix |
+| `feat!:` or a `BREAKING CHANGE:` footer | major bump | a breaking change |
+| `perf:` | patch bump | a performance fix |
+| `docs:` / `chore:` / `ci:` / `refactor:` / `style:` / `test:` / `build:` | **no release** | changes that intentionally shouldn't ship a new version |
+
+**To force a release for a change that isn't a `feat`/`fix`** (e.g. a CI-only or workflow-only
+change that still needs to be built and published), use the `force-patch` scope:
+
+```
+ci(force-patch): <description>
+```
+
+`.releaserc.json`'s `commit-analyzer` `releaseRules` maps the `force-patch` scope to a patch
+release. There is also a `no-release` scope for the opposite intent (explicitly suppress a
+release).
+
+**Never** write a plain, prefix-less commit message on a branch that is expected to build.

--- a/epi-crestron-iptable-editor.4Series.sln
+++ b/epi-crestron-iptable-editor.4Series.sln
@@ -5,19 +5,52 @@ VisualStudioVersion = 17.11.35327.3
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "epi-crestron-iptable-editor.4Series", "src\epi-crestron-iptable-editor.4Series.csproj", "{52E6E0A0-A710-4B5F-AF52-08816F5C99BB}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05-4346-4AA6-1389-037BE0695223}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "epi-crestron-iptable-editor.Tests", "tests\epi-crestron-iptable-editor.Tests.csproj", "{EADC022A-B6DB-4EB8-ADD5-ED443CD47615}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{52E6E0A0-A710-4B5F-AF52-08816F5C99BB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{52E6E0A0-A710-4B5F-AF52-08816F5C99BB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{52E6E0A0-A710-4B5F-AF52-08816F5C99BB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{52E6E0A0-A710-4B5F-AF52-08816F5C99BB}.Debug|x64.Build.0 = Debug|Any CPU
+		{52E6E0A0-A710-4B5F-AF52-08816F5C99BB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{52E6E0A0-A710-4B5F-AF52-08816F5C99BB}.Debug|x86.Build.0 = Debug|Any CPU
 		{52E6E0A0-A710-4B5F-AF52-08816F5C99BB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{52E6E0A0-A710-4B5F-AF52-08816F5C99BB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{52E6E0A0-A710-4B5F-AF52-08816F5C99BB}.Release|x64.ActiveCfg = Release|Any CPU
+		{52E6E0A0-A710-4B5F-AF52-08816F5C99BB}.Release|x64.Build.0 = Release|Any CPU
+		{52E6E0A0-A710-4B5F-AF52-08816F5C99BB}.Release|x86.ActiveCfg = Release|Any CPU
+		{52E6E0A0-A710-4B5F-AF52-08816F5C99BB}.Release|x86.Build.0 = Release|Any CPU
+		{EADC022A-B6DB-4EB8-ADD5-ED443CD47615}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EADC022A-B6DB-4EB8-ADD5-ED443CD47615}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EADC022A-B6DB-4EB8-ADD5-ED443CD47615}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EADC022A-B6DB-4EB8-ADD5-ED443CD47615}.Debug|x64.Build.0 = Debug|Any CPU
+		{EADC022A-B6DB-4EB8-ADD5-ED443CD47615}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EADC022A-B6DB-4EB8-ADD5-ED443CD47615}.Debug|x86.Build.0 = Debug|Any CPU
+		{EADC022A-B6DB-4EB8-ADD5-ED443CD47615}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EADC022A-B6DB-4EB8-ADD5-ED443CD47615}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EADC022A-B6DB-4EB8-ADD5-ED443CD47615}.Release|x64.ActiveCfg = Release|Any CPU
+		{EADC022A-B6DB-4EB8-ADD5-ED443CD47615}.Release|x64.Build.0 = Release|Any CPU
+		{EADC022A-B6DB-4EB8-ADD5-ED443CD47615}.Release|x86.ActiveCfg = Release|Any CPU
+		{EADC022A-B6DB-4EB8-ADD5-ED443CD47615}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{EADC022A-B6DB-4EB8-ADD5-ED443CD47615} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {45BE70E2-A4DC-4851-92ED-CE67B99F5D86}

--- a/src/IPTableFactory.cs
+++ b/src/IPTableFactory.cs
@@ -19,7 +19,7 @@ namespace PepperDash.Essentials.Plugins.Crestron.IpTable_Editor
 		/// <inheritdoc/>
 		public IpTableEditorFactory()
 		{
-			MinimumEssentialsFrameworkVersion = "2.12.1";
+			MinimumEssentialsFrameworkVersion = "3.0.0-dev-v3-routing.63";
 			TypeNames = new List<string> { "IPTableEditor" };
 		}
 

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -6,4 +6,3 @@
 [assembly: AssemblyCopyright("Copyright ©  2021")]
 [assembly: AssemblyVersion("0.0.0.*")]
 [assembly: AssemblyInformationalVersion("0.0.0-buildtype-buildnumber")]
-[assembly: Crestron.SimplSharp.Reflection.AssemblyInformationalVersion("0.0.0-buildtype-buildnumber")]

--- a/src/epi-crestron-iptable-editor.4Series.csproj
+++ b/src/epi-crestron-iptable-editor.4Series.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<ProjectType>ProgramLibrary</ProjectType>
 	</PropertyGroup>
 	<PropertyGroup>
-		<TargetFramework>net472</TargetFramework>
+		<TargetFramework>net8</TargetFramework>
 		<RootNamespace>PepperDash.Essentials.Plugins.Crestron.IpTable_Editor</RootNamespace>
 		<Deterministic>false</Deterministic>
 		<AssemblyTitle>PepperDash.Essentials.Plugins.Crestron.IpTable_Editor</AssemblyTitle>
@@ -20,14 +20,6 @@
 		<PackageTags>crestron 4series essentials iptable editor</PackageTags>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-		<DefineConstants>$(DefineConstants);SERIES4</DefineConstants>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-		<DefineConstants>$(DefineConstants);SERIES4</DefineConstants>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<Compile Remove="Properties\**" />
 		<EmbeddedResource Remove="Properties\**" />
@@ -39,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
- 	<PackageReference Include="PepperDashEssentials" Version="2.12.1" >
+ 	<PackageReference Include="PepperDashEssentials" Version="3.0.0-dev-v3-routing.63" >
   		<ExcludeAssets>runtime</ExcludeAssets>
  	</PackageReference>
   </ItemGroup>

--- a/src/epi-crestron-iptable-editor.4Series.csproj
+++ b/src/epi-crestron-iptable-editor.4Series.csproj
@@ -5,6 +5,7 @@
 	<PropertyGroup>
 		<TargetFramework>net8</TargetFramework>
 		<RootNamespace>PepperDash.Essentials.Plugins.Crestron.IpTable_Editor</RootNamespace>
+		<AssemblyName>PepperDash.Essentials.Plugins.Crestron.IpTable_Editor</AssemblyName>
 		<Deterministic>false</Deterministic>
 		<AssemblyTitle>PepperDash.Essentials.Plugins.Crestron.IpTable_Editor</AssemblyTitle>
 		<Company>PepperDash Technology</Company>

--- a/tests/AssemblyFixture.cs
+++ b/tests/AssemblyFixture.cs
@@ -1,0 +1,174 @@
+using System.Reflection;
+using System.Text.Json;
+
+namespace PepperDash.Essentials.Plugins.Crestron.IpTable_Editor.Tests;
+
+public static class AssemblyFixture
+{
+    private static readonly Lazy<MetadataLoadContext> LazyContext = new(CreateContext);
+    private static readonly Lazy<Assembly> LazyAssembly = new(LoadPluginAssembly);
+
+    private static string Configuration
+    {
+        get
+        {
+            // Derive from test output path: tests/bin/{Configuration}/net8.0/
+            var baseDir = AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar);
+            var parts = baseDir.Split(Path.DirectorySeparatorChar);
+            return parts[^2]; // net8.0 is last, Configuration is second-to-last
+        }
+    }
+
+    // Flat <OutputPath>bin\$(Configuration)\</OutputPath> -> src/bin/{Config}/net8/...
+    private static string PluginDllPath =>
+        Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "..", "..", "..", "..",
+            "src", "bin", Configuration, "net8",
+            "PepperDash.Essentials.Plugins.Crestron.IpTable_Editor.dll"));
+
+    private static string PluginOutputDir => Path.GetDirectoryName(PluginDllPath)!;
+
+    public static MetadataLoadContext Context => LazyContext.Value;
+    public static Assembly PluginAssembly => LazyAssembly.Value;
+
+    private static MetadataLoadContext CreateContext()
+    {
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+        var dllByName = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        // Fail clearly if the plugin hasn't been built yet, rather than letting
+        // Directory.GetFiles throw a less actionable DirectoryNotFoundException below.
+        if (!File.Exists(PluginDllPath))
+            throw new FileNotFoundException(
+                $"Plugin DLL not found at '{PluginDllPath}'. Build the plugin first.", PluginDllPath);
+
+        // Priority 1: Plugin output dir (correct versions win)
+        foreach (var dll in Directory.GetFiles(PluginOutputDir, "*.dll"))
+            dllByName[Path.GetFileName(dll)] = dll;
+
+        // Priority 2: .NET runtime
+        foreach (var dll in Directory.GetFiles(runtimeDir, "*.dll"))
+            dllByName.TryAdd(Path.GetFileName(dll), dll);
+
+        // Priority 3: project.assets.json resolution for transitive packages.
+        // NOT deps.json - plugin csproj uses <ExcludeAssets>runtime</ExcludeAssets> on the
+        // PepperDashEssentials reference (Essentials itself provides those DLLs on the
+        // processor at runtime), so the plugin's own deps.json omits every dependency
+        // entirely and this resolver would find nothing. project.assets.json has the full
+        // pre-exclusion dependency graph and is present after any restore/build.
+        var assetsJsonPath = Path.Combine(SourceDirectory, "obj", "project.assets.json");
+        if (File.Exists(assetsJsonPath))
+        {
+            foreach (var path in ResolveProjectAssetsAssemblies(assetsJsonPath))
+                dllByName.TryAdd(Path.GetFileName(path), path);
+        }
+
+        return new MetadataLoadContext(new PathAssemblyResolver(dllByName.Values));
+    }
+
+    private static IEnumerable<string> ResolveProjectAssetsAssemblies(string assetsJsonPath)
+    {
+        // Honor NUGET_PACKAGES (common in CI / enterprise setups); fall back to the default.
+        var nugetDir = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+        if (string.IsNullOrWhiteSpace(nugetDir))
+            nugetDir = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                ".nuget", "packages");
+
+        using var stream = File.OpenRead(assetsJsonPath);
+        using var doc = JsonDocument.Parse(stream);
+
+        if (!doc.RootElement.TryGetProperty("targets", out var targets))
+            yield break;
+
+        // Exactly one TFM per build - take whichever key is present rather than
+        // hard-coding "net8" (restores can key it slightly differently).
+        var target = targets.EnumerateObject().FirstOrDefault();
+        if (target.Value.ValueKind != JsonValueKind.Object)
+            yield break;
+
+        foreach (var lib in target.Value.EnumerateObject())
+        {
+            // Library key is "PackageId/Version"
+            var slash = lib.Name.LastIndexOf('/');
+            if (slash < 0) continue;
+            var packageId = lib.Name[..slash].ToLowerInvariant();
+            var version = lib.Name[(slash + 1)..];
+
+            if (!lib.Value.TryGetProperty("compile", out var assets) &&
+                !lib.Value.TryGetProperty("runtime", out assets))
+                continue;
+
+            foreach (var asset in assets.EnumerateObject())
+            {
+                // "_._" is NuGet's placeholder for "no asset of this kind" - skip it.
+                if (!asset.Name.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                var dllPath = Path.Combine(nugetDir, packageId, version,
+                    asset.Name.Replace('/', Path.DirectorySeparatorChar));
+                if (File.Exists(dllPath))
+                    yield return dllPath;
+            }
+        }
+    }
+
+    private static Assembly LoadPluginAssembly()
+    {
+        if (!File.Exists(PluginDllPath))
+            throw new FileNotFoundException(
+                $"Plugin DLL not found at '{PluginDllPath}'. Build the plugin first.", PluginDllPath);
+        return Context.LoadFromAssemblyPath(PluginDllPath);
+    }
+
+    // Walks the FULL base-type chain — handles factories that derive through an intermediate
+    // base, not just direct subclasses. A direct-BaseType-only check silently misses those.
+    public static List<Type> FindFactoryTypes(string baseTypePrefix = "EssentialsPluginDeviceFactory")
+    {
+        return PluginAssembly.GetTypes()
+            .Where(t => !t.IsAbstract && InheritsFromFactory(t, baseTypePrefix))
+            .ToList();
+    }
+
+    private static bool InheritsFromFactory(Type type, string prefix)
+    {
+        for (var b = type.BaseType; b != null; b = b.BaseType)
+            if (b.IsGenericType && b.GetGenericTypeDefinition().Name.StartsWith(prefix))
+                return true;
+        return false;
+    }
+
+    public static string SourceDirectory =>
+        Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory, "..", "..", "..", "..", "src"));
+
+    // Read every source file once, then search in memory — FactoryMetadataTests calls this per
+    // factory, so re-enumerating/re-reading src/*.cs on every call is avoidable IO.
+    private static readonly Lazy<string[]> AllSourceContents = new(() =>
+        Directory.GetFiles(SourceDirectory, "*.cs", SearchOption.AllDirectories)
+            // Skip build output (src/bin, src/obj) so we don't read generated .cs or match generated code.
+            .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}")
+                     && !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}"))
+            .Select(File.ReadAllText)
+            .ToArray());
+
+    public static string? FindSourceForClass(string className) =>
+        AllSourceContents.Value.FirstOrDefault(content => DeclaresClass(content, className));
+
+    // Match "class <name>" only when <name> ends on a non-identifier boundary, so a prefix
+    // like "Foo" does not match "class FooBar". Avoids a regex (keeps the helper allocation-light).
+    private static bool DeclaresClass(string content, string className)
+    {
+        var needle = "class " + className;
+        for (var i = content.IndexOf(needle, StringComparison.Ordinal); i >= 0;
+             i = content.IndexOf(needle, i + 1, StringComparison.Ordinal))
+        {
+            var after = i + needle.Length;
+            var next = after < content.Length ? content[after] : ' ';
+            if (!char.IsLetterOrDigit(next) && next != '_')
+                return true;
+        }
+        return false;
+    }
+}

--- a/tests/ConfigDeserializationTests.cs
+++ b/tests/ConfigDeserializationTests.cs
@@ -1,0 +1,57 @@
+using FluentAssertions;
+using Xunit;
+
+namespace PepperDash.Essentials.Plugins.Crestron.IpTable_Editor.Tests;
+
+public class ConfigDeserializationTests
+{
+    private static Type GetConfigType(string name) =>
+        AssemblyFixture.PluginAssembly.GetTypes().Single(t => t.Name == name);
+
+    [Theory]
+    [InlineData("IpTableEditorConfigObject")]
+    [InlineData("IpTableObjectBase")]
+    [InlineData("IpTableChangesConfigObject")]
+    public void Config_Class_Exists(string className)
+    {
+        AssemblyFixture.PluginAssembly.GetTypes()
+            .Should().Contain(t => t.Name == className);
+    }
+
+    [Theory]
+    [InlineData("IpTableEditorConfigObject")]
+    [InlineData("IpTableChangesConfigObject")]
+    public void Config_Has_Parameterless_Constructor(string className)
+    {
+        var type = GetConfigType(className);
+        type.GetConstructor(Type.EmptyTypes).Should().NotBeNull();
+    }
+
+    [Theory]
+    [InlineData("IpTableEditorConfigObject", "IpTableChanges", "ipTableChanges")]
+    [InlineData("IpTableEditorConfigObject", "RunAtStartup", "runAtStartup")]
+    [InlineData("IpTableEditorConfigObject", "Control", "control")]
+    [InlineData("IpTableEditorConfigObject", "PersistentEntry", "persistentEntry")]
+    [InlineData("IpTableEditorConfigObject", "SelectableEntries", "selectableEntries")]
+    [InlineData("IpTableObjectBase", "IpId", "ipId")]
+    [InlineData("IpTableObjectBase", "IpAddress", "ipAddress")]
+    [InlineData("IpTableObjectBase", "RoomId", "roomId")]
+    [InlineData("IpTableChangesConfigObject", "Name", "name")]
+    [InlineData("IpTableChangesConfigObject", "DevId", "devId")]
+    [InlineData("IpTableChangesConfigObject", "IpPort", "ipPort")]
+    [InlineData("IpTableChangesConfigObject", "ProgramNumber", "programNumber")]
+    public void Config_Property_Has_JsonPropertyAttribute(string className, string propertyName, string jsonName)
+    {
+        var type = GetConfigType(className);
+        var property = type.GetProperty(propertyName);
+        property.Should().NotBeNull($"{className} should declare property {propertyName}");
+
+        var hasAttribute = property!.CustomAttributes.Any(a =>
+            a.AttributeType.Name == "JsonPropertyAttribute"
+            && a.ConstructorArguments.Any(arg =>
+                string.Equals(arg.Value?.ToString(), jsonName, StringComparison.Ordinal)));
+
+        hasAttribute.Should().BeTrue(
+            $"{className}.{propertyName} should have [JsonProperty(\"{jsonName}\")]");
+    }
+}

--- a/tests/FactoryDiscoveryTests.cs
+++ b/tests/FactoryDiscoveryTests.cs
@@ -1,0 +1,45 @@
+using FluentAssertions;
+using Xunit;
+
+namespace PepperDash.Essentials.Plugins.Crestron.IpTable_Editor.Tests;
+
+public class FactoryDiscoveryTests
+{
+    [Fact]
+    public void Assembly_Loads_Successfully()
+    {
+        AssemblyFixture.PluginAssembly.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Assembly_Name_Matches_Expected()
+    {
+        AssemblyFixture.PluginAssembly.GetName().Name
+            .Should().Be("PepperDash.Essentials.Plugins.Crestron.IpTable_Editor");
+    }
+
+    [Fact]
+    public void Factory_Count_Matches_Expected()
+    {
+        AssemblyFixture.FindFactoryTypes().Should().HaveCount(1);
+    }
+
+    [Theory]
+    [InlineData("IpTableEditorFactory")]
+    public void Factory_Exists_ByName(string factoryName)
+    {
+        AssemblyFixture.FindFactoryTypes()
+            .Select(t => t.Name)
+            .Should().Contain(factoryName);
+    }
+
+    [Fact]
+    public void All_Factories_Have_Parameterless_Constructor()
+    {
+        foreach (var factory in AssemblyFixture.FindFactoryTypes())
+        {
+            factory.GetConstructor(Type.EmptyTypes)
+                .Should().NotBeNull($"{factory.Name} must have a parameterless constructor for plugin discovery");
+        }
+    }
+}

--- a/tests/FactoryMetadataTests.cs
+++ b/tests/FactoryMetadataTests.cs
@@ -1,0 +1,63 @@
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using Xunit;
+
+namespace PepperDash.Essentials.Plugins.Crestron.IpTable_Editor.Tests;
+
+public class FactoryMetadataTests
+{
+    // Matches the pinned prerelease this plugin actually targets - NOT the plain "3.0.0" seen
+    // in some doc examples, which doesn't exist as a shipped Essentials version.
+    private const string ExpectedMinimumEssentialsFrameworkVersion = "3.0.0-dev-v3-routing.63";
+
+    [Theory]
+    [InlineData("IpTableEditorFactory")]
+    public void Factory_Source_Sets_MinimumEssentialsFrameworkVersion(string factoryName)
+    {
+        var source = AssemblyFixture.FindSourceForClass(factoryName);
+        source.Should().NotBeNull($"source for {factoryName} should be found under src/");
+
+        source!.Should().Contain(
+            $"MinimumEssentialsFrameworkVersion = \"{ExpectedMinimumEssentialsFrameworkVersion}\"");
+    }
+
+    [Theory]
+    [InlineData("IpTableEditorFactory")]
+    public void Factory_Source_Sets_TypeNames(string factoryName)
+    {
+        var source = AssemblyFixture.FindSourceForClass(factoryName);
+        source.Should().NotBeNull();
+        source!.Should().Contain("TypeNames = new List<string>");
+    }
+
+    [Theory]
+    [InlineData("IpTableEditorFactory", "IPTableEditor")]
+    public void Factory_Source_Contains_TypeName(string factoryName, string typeName)
+    {
+        var source = AssemblyFixture.FindSourceForClass(factoryName);
+        source.Should().NotBeNull();
+        source!.Should().Contain($"\"{typeName}\"");
+    }
+
+    [Fact]
+    public void No_Duplicate_TypeNames_Across_Factory_Sources()
+    {
+        var factoryNames = new[] { "IpTableEditorFactory" };
+        var allTypeNames = new List<string>();
+
+        foreach (var factoryName in factoryNames)
+        {
+            var source = AssemblyFixture.FindSourceForClass(factoryName);
+            source.Should().NotBeNull();
+
+            var match = Regex.Match(source!, @"TypeNames\s*=\s*new List<string>\s*\{([^}]*)\}");
+            match.Success.Should().BeTrue($"{factoryName} should assign TypeNames in its constructor");
+
+            var names = Regex.Matches(match.Groups[1].Value, "\"([^\"]+)\"")
+                .Select(m => m.Groups[1].Value);
+            allTypeNames.AddRange(names);
+        }
+
+        allTypeNames.Should().OnlyHaveUniqueItems();
+    }
+}

--- a/tests/epi-crestron-iptable-editor.Tests.csproj
+++ b/tests/epi-crestron-iptable-editor.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="7.0.0" />
+    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="9.0.4" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Ensures the plugin is built before tests run (no direct assembly reference) -->
+    <ProjectReference Include="..\src\epi-crestron-iptable-editor.4Series.csproj" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## What changed

Migrates this plugin from v2 (net472, SERIES4 conditionals) to v3 (net8 SDK-style). Drops 3-Series support.

- csproj: TargetFramework net472 -> net8; removed both SERIES4 PropertyGroup conditionals; PepperDashEssentials -> 3.0.0-dev-v3-routing.63
- Factory: MinimumEssentialsFrameworkVersion -> 3.0.0-dev-v3-routing.63 (matches the actual pinned prerelease, not a nonexistent stable 3.0.0)
- Removed the net8-incompatible Crestron.SimplSharp.Reflection assembly attribute in AssemblyInfo.cs (redundant with the existing System.Reflection one)

Device classes, join maps, and logging required no changes: no #if SERIES4 blocks in source, 0 Debug.Console calls (logging was already Serilog-style), no Initialize()/CustomActivate() overrides, join maps already conform.

## Verification

- Baseline v2 build: clean, 0 errors
- Post-migration net8 build: clean, 0 warnings, 0 errors

## Note

PepperDashEssentials 3.0.0-dev-v3-routing.63 is a prerelease pin (no stable 3.x has shipped yet) -- re-verify against nuget.org before merging in case a newer prerelease is available.

## Breaking change

Drops 3-Series support -- requires Essentials v3 and a 4-Series processor.